### PR TITLE
Added workflows to publish snapshots and releases to Maven Central.

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,43 @@
+name: Release to Maven Staging
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build project and publish release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: ossrh-release
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+    - name: Extract project version
+      id: project
+      run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: Publish to Maven central
+      if: ${{ !endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
+      run: mvn deploy --file pom.xml
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.project.outputs.version }}
+        release_name: ${{ steps.project.outputs.version }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -1,0 +1,31 @@
+name: Build and Publish SNAPSHOT
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build project and publish SNAPSHOT
+    runs-on: ubuntu-latest  
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set up java for publishing snapshot
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          server-id: ossrh-snapshot
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Extract project version
+        id: project
+        run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+      - name: Publish to snapshot repo
+        if: ${{ endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
+        run: mvn clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

Highly inspired from https://github.com/aws/random-cut-forest-by-aws/pull/334 and https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven. 

Will need `MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE`, `OSSRH_USERNAME` and `OSSRH_TOKEN` in repo secrets. There's a pretty good explanation in https://dzone.com/articles/how-to-publish-artifacts-to-maven-central of how to get all those things if you need help. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
