### PR TITLE
Fix: signing POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.0.3 (Next)
 
+* [#31](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/31): Fix signing HTTP POST requests - [@dblock](https://github.com/dblock).
 * [#28](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/28): Run tests on push and pull - [@dblock](https://github.com/dblock).
 * [#25](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/25): Added CHANGELOG - [@dblock](https://github.com/dblock).
 * [#24](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/24): Added checkstyle - [@dblock](https://github.com/dblock).

--- a/src/main/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptor.java
+++ b/src/main/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptor.java
@@ -34,7 +34,8 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.regions.Region;
 
 /**
- * An {@link HttpRequestInterceptor} that signs requests using any AWS {@link Signer}
+ * An {@link HttpRequestInterceptor} that signs requests using any AWS
+ * {@link Signer}
  * and {@link AwsCredentialsProvider}.
  */
 public class AwsRequestSigningApacheInterceptor implements HttpRequestInterceptor {
@@ -60,15 +61,15 @@ public class AwsRequestSigningApacheInterceptor implements HttpRequestIntercepto
 
     /**
      *
-     * @param service service that we're connecting to
-     * @param signer particular signer implementation
+     * @param service                service that we're connecting to
+     * @param signer                 particular signer implementation
      * @param awsCredentialsProvider source of AWS credentials for signing
-     * @param region signing region
+     * @param region                 signing region
      */
     public AwsRequestSigningApacheInterceptor(final String service,
-                                              final Signer signer,
-                                              final AwsCredentialsProvider awsCredentialsProvider,
-                                              final Region region) {
+            final Signer signer,
+            final AwsCredentialsProvider awsCredentialsProvider,
+            final Region region) {
         this.service = service;
         this.signer = signer;
         this.awsCredentialsProvider = awsCredentialsProvider;
@@ -77,15 +78,15 @@ public class AwsRequestSigningApacheInterceptor implements HttpRequestIntercepto
 
     /**
      *
-     * @param service service that we're connecting to
-     * @param signer particular signer implementation
+     * @param service                service that we're connecting to
+     * @param signer                 particular signer implementation
      * @param awsCredentialsProvider source of AWS credentials for signing
-     * @param region signing region
+     * @param region                 signing region
      */
     public AwsRequestSigningApacheInterceptor(final String service,
-                                              final Signer signer,
-                                              final AwsCredentialsProvider awsCredentialsProvider,
-                                              final String region) {
+            final Signer signer,
+            final AwsCredentialsProvider awsCredentialsProvider,
+            final String region) {
         this(service, signer, awsCredentialsProvider, Region.of(region));
     }
 
@@ -108,8 +109,7 @@ public class AwsRequestSigningApacheInterceptor implements HttpRequestIntercepto
                 .uri(buildUri(context, uriBuilder));
 
         if (request instanceof HttpEntityEnclosingRequest) {
-            HttpEntityEnclosingRequest httpEntityEnclosingRequest =
-                    (HttpEntityEnclosingRequest) request;
+            HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) request;
             if (httpEntityEnclosingRequest.getEntity() != null) {
                 final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 httpEntityEnclosingRequest.getEntity().writeTo(outputStream);
@@ -120,7 +120,8 @@ public class AwsRequestSigningApacheInterceptor implements HttpRequestIntercepto
         requestBuilder.headers(headerArrayToMap(request.getAllHeaders()));
 
         ExecutionAttributes attributes = new ExecutionAttributes();
-        attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, awsCredentialsProvider.resolveCredentials());
+        attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS,
+                awsCredentialsProvider.resolveCredentials());
         attributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, service);
         attributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, region);
 
@@ -131,8 +132,7 @@ public class AwsRequestSigningApacheInterceptor implements HttpRequestIntercepto
         request.setHeaders(mapToHeaderArray(signedRequest.headers()));
 
         if (request instanceof HttpEntityEnclosingRequest) {
-            HttpEntityEnclosingRequest httpEntityEnclosingRequest =
-                    (HttpEntityEnclosingRequest) request;
+            HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) request;
             if (httpEntityEnclosingRequest.getEntity() != null) {
                 BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
                 basicHttpEntity.setContent(signedRequest.contentStreamProvider()
@@ -167,8 +167,7 @@ public class AwsRequestSigningApacheInterceptor implements HttpRequestIntercepto
     private static Map<String, List<String>> nvpToMapParams(final List<NameValuePair> params) {
         Map<String, List<String>> parameterMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (NameValuePair nvp : params) {
-            List<String> argsList =
-                    parameterMap.computeIfAbsent(nvp.getName(), k -> new ArrayList<>());
+            List<String> argsList = parameterMap.computeIfAbsent(nvp.getName(), k -> new ArrayList<>());
             argsList.add(nvp.getValue());
         }
         return parameterMap;

--- a/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
@@ -1,39 +1,56 @@
 package io.github.acm19.aws.interceptor.test;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
 
 import software.amazon.awssdk.regions.Region;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
 
 /**
- * <p>An AWS Request Signing Interceptor sample for arbitrary HTTP requests to an Amazon OpenSearch Service domain.</p>
- * <p>The interceptor can also be used with the OpenSearch REST clients for additional convenience and serialization.</p>
- * <p>Example usage with the OpenSearch low-level REST client:</p>
+ * <p>
+ * An AWS Request Signing Interceptor sample for arbitrary HTTP requests to an
+ * Amazon OpenSearch Service domain.
+ * </p>
+ * <p>
+ * The interceptor can also be used with the OpenSearch REST clients for
+ * additional convenience and serialization.
+ * </p>
+ * <p>
+ * Example usage with the OpenSearch low-level REST client:
+ * </p>
+ * 
  * <pre>
  * String serviceName = "es";
  * Aws4Signer signer = Aws4Signer.create();
  *
- * HttpRequestInterceptor interceptor =
- *     new AwsRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider, "us-east-1");
+ * HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider,
+ *         "us-east-1");
  *
  * return RestClient
- *     .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
- *     .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor))
- *     .build();
+ *         .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
+ *         .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor))
+ *         .build();
  * </pre>
- * <p>Example usage with the OpenSearch high-level REST client:</p>
+ * <p>
+ * Example usage with the OpenSearch high-level REST client:
+ * </p>
+ * 
  * <pre>
  * String serviceName = "es";
  * Aws4Signer signer = Aws4Signer.create();
  *
- * HttpRequestInterceptor interceptor =
- *     new AwsRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider, "us-east-1");
+ * HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider,
+ *         "us-east-1");
  *
  * return new RestHighLevelClient(RestClient
- *     .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
- *     .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
+ *         .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
+ *         .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
  * </pre>
  */
 public class AmazonOpenSearchServiceSample extends Sample {
@@ -42,11 +59,12 @@ public class AmazonOpenSearchServiceSample extends Sample {
 
     public static void main(String[] args) throws IOException {
         AmazonOpenSearchServiceSample sample = new AmazonOpenSearchServiceSample();
-        sample.makeAESRequest();
+        sample.makeRequest();
         sample.indexDocument();
+        sample.indexDocumentWithCompressionEnabled();
     }
 
-    private void makeAESRequest() throws IOException {
+    private void makeRequest() throws IOException {
         HttpGet httpGet = new HttpGet(ENDPOINT);
         logRequest("es", REGION, httpGet);
     }
@@ -55,6 +73,23 @@ public class AmazonOpenSearchServiceSample extends Sample {
         String payload = "{\"test\": \"val\"}";
         HttpPost httpPost = new HttpPost(ENDPOINT + "/index_name/type_name/document_id");
         httpPost.setEntity(stringEntity(payload));
+        httpPost.addHeader("Content-Type", "application/json");
+        logRequest("es", REGION, httpPost);
+    }
+
+    private void indexDocumentWithCompressionEnabled() throws IOException {
+        String payload = "{\"test\": \"val\"}";
+        HttpPost httpPost = new HttpPost(ENDPOINT + "/index_name/type_name/document_id");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
+        gzipOutputStream.write(payload.getBytes("UTF-8"));
+        gzipOutputStream.close();
+        ByteArrayEntity entity = new ByteArrayEntity(
+                outputStream.toByteArray(),
+                ContentType.DEFAULT_BINARY);
+        entity.setContentEncoding("gzip");
+        httpPost.setHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
+        httpPost.setEntity(entity);
         httpPost.addHeader("Content-Type", "application/json");
         logRequest("es", REGION, httpPost);
     }

--- a/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
@@ -6,7 +6,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.http.HttpEntity;
@@ -80,7 +79,10 @@ class Sample {
 
     HttpEntity stringEntity(final String body) throws UnsupportedEncodingException {
         BasicHttpEntity httpEntity = new BasicHttpEntity();
-        httpEntity.setContent(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8.name())));
+        httpEntity.setContentType("text/html; charset=UTF-8");
+        final byte[] bodyData = body.getBytes();
+        httpEntity.setContent(new ByteArrayInputStream(bodyData));
+        httpEntity.setContentLength(bodyData.length);
         return httpEntity;
     }
 }

--- a/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
@@ -1,18 +1,11 @@
 package io.github.acm19.aws.interceptor.test;
 
-import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheInterceptor;
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.zip.GZIPOutputStream;
 
-import org.apache.commons.codec.binary.StringUtils;
-import org.apache.http.HttpException;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -20,12 +13,11 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
+
+import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheInterceptor;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
@@ -55,13 +47,13 @@ class Sample {
     }
 
     void logRequest(String serviceName, Region region, HttpUriRequest request) throws IOException {
-        System.setProperty("org.apache.commons.logging.Log","org.apache.commons.logging.impl.SimpleLog");
+        System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
         System.setProperty("org.apache.commons.logging.simplelog.showdatetime", "true");
         System.setProperty("org.apache.commons.logging.simplelog.log.org.apache.http.wire", "DEBUG");
         CloseableHttpClient httpClient = signingClientForServiceName(serviceName, region);
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             System.out.println(response.getStatusLine());
-            String inputLine ;
+            String inputLine;
             BufferedReader br = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
             try {
                 while ((inputLine = br.readLine()) != null) {
@@ -71,7 +63,7 @@ class Sample {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            switch(response.getStatusLine().getStatusCode()) {
+            switch (response.getStatusLine().getStatusCode()) {
                 case 200:
                 case 201:
                     break;
@@ -84,28 +76,10 @@ class Sample {
     CloseableHttpClient signingClientForServiceName(String serviceName, Region region) {
         Aws4Signer signer = Aws4Signer.create();
 
-        HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider, region);
+        HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(serviceName, signer,
+                credentialsProvider, region);
         return HttpClients.custom()
                 .addInterceptorLast(interceptor)
                 .build();
-    }
-
-    BasicHttpEntity stringEntity(final String body) throws UnsupportedEncodingException {
-        BasicHttpEntity httpEntity = new BasicHttpEntity();
-        httpEntity.setContentType("text/html; charset=UTF-8");
-        final byte[] bodyData = StringUtils.getBytesUtf8(body);
-        httpEntity.setContent(new ByteArrayInputStream(bodyData));
-        httpEntity.setContentLength(bodyData.length);
-        return httpEntity;
-    }
-
-    ByteArrayEntity gzipEntity(final String body) throws IOException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
-        gzipOutputStream.write(body.getBytes("UTF-8"));
-        gzipOutputStream.close();
-        ByteArrayEntity entity = new ByteArrayEntity(outputStream.toByteArray(), ContentType.DEFAULT_BINARY);
-        entity.setContentEncoding("gzip");
-        return entity;
     }
 }


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

The interceptor consumes a stream of data, then copies the data back to the original request. The fix is in the interceptor code: create a new stream for the data to avoid having consumed it all (there would be nothing left to copy when copying back). Added a unit test for HTTP POST that covers checking that the content is still present after signing the data.

The second change is to correctly write the JSON string and properly calculate its content length. Otherwise we end up sending \0 along for the ride. That's only a bug in the HTTP demo, thus the @acm19 version described in #29 was working. I also added demos for gzipped content and failing demos for the same with chunked transfer encoding.

Closes https://github.com/acm19/aws-request-signing-apache-interceptor/issues/29.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
