### PR TITLE
Pass values of host and region as command line arguments into samples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ public static void main(String[] args) throws ClientProtocolException, IOExcepti
 
 ## Examples
 
-To run the [Amazon OpenSearch Sample](src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java), replace the values of `host` and `region` in the source and run the following. 
+To run the [Amazon OpenSearch Sample](src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java) pass the values of _host_ and _region_ into `exec.args`.
 
 ```
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
 export AWS_SESSION_TOKEN=
 
-mvn test-compile exec:java -Dexec.classpathScope=test -Dexec.mainClass="io.github.acm19.aws.interceptor.test.AmazonOpenSearchServiceSample"
+mvn test-compile exec:java -Dexec.classpathScope=test -Dexec.mainClass="io.github.acm19.aws.interceptor.test.AmazonOpenSearchServiceSample" -Dexec.args="--endpoint=https://search-dblock-test-opensearch-21-tu5gqrjd4vg4qazjsu6bps5zsy.us-west-2.es.amazonaws.com --region=us-west-2"
 ```
 
 See [examples](src/test/java/io/github/acm19/aws/interceptor/test) for more valid requests. 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -103,7 +103,6 @@
     <module name="InvalidJavadocPosition"/>
     <module name="JavadocMethod"/>
     <module name="JavadocType"/>
-    <!-- <module name="JavadocVariable"/> -->
     <module name="JavadocStyle"/>
     <module name="MissingJavadocMethod"/>
 
@@ -163,7 +162,6 @@
     <!-- See https://checkstyle.org/config_coding.html -->
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
-    <!--module name="HiddenField"/-->
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>
     <module name="MagicNumber"/>
@@ -178,7 +176,6 @@
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>
-    <module name="VisibilityModifier"/>
 
     <!-- Miscellaneous other checks.                   -->
     <!-- See https://checkstyle.org/config_misc.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+        <version>2.17.226</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -53,18 +65,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-        <version>2.17.226</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
-      <scope>provided</scope>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/io/github/acm19/aws/interceptor/test/APIGatewaySample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/APIGatewaySample.java
@@ -10,30 +10,27 @@ package io.github.acm19.aws.interceptor.test;
 
 import java.io.IOException;
 
+import org.apache.commons.cli.ParseException;
 import org.apache.http.client.methods.HttpGet;
 
-import software.amazon.awssdk.regions.Region;
-
 public class APIGatewaySample extends Sample {
-    /**
-     * The invoke URL for your API which is usually
-     * https://api_id.execute-api.api-region.amazonaws.com/stage.
-     */
-    private static final String INVOKE_URL = "https://api_id.execute-api.api-region.amazonaws.com/stage";
-    private static final Region REGION = Region.US_EAST_1;
+    APIGatewaySample(final String[] args) throws ParseException {
+        super("execute-api", args);
+    }
 
     /**
      *
      * @param args
      * @throws IOException
+     * @throws ParseException
      */
-    public static void main(final String[] args) throws IOException {
-        APIGatewaySample apiGatewaySample = new APIGatewaySample();
+    public static void main(final String[] args) throws IOException, ParseException {
+        APIGatewaySample apiGatewaySample = new APIGatewaySample(args);
         apiGatewaySample.makeAPIGGetRequest();
     }
 
     private void makeAPIGGetRequest() throws IOException {
-        final HttpGet request = new HttpGet(INVOKE_URL + "/some/path?and=param");
-        logRequest("execute-api", REGION, request);
+        final HttpGet request = new HttpGet(endpoint + "/some/path?and=param");
+        logRequest(request);
     }
 }

--- a/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
 
+import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -19,8 +20,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-
-import software.amazon.awssdk.regions.Region;
 
 /**
  * An AWS Request Signing Interceptor sample for arbitrary HTTP requests to an
@@ -63,16 +62,18 @@ import software.amazon.awssdk.regions.Region;
  * </pre>
  */
 public class AmazonOpenSearchServiceSample extends Sample {
-    private static final String ENDPOINT = "https://search-dblock-test-opensearch-21-tu5gqrjd4vg4qazjsu6bps5zsy.us-west-2.es.amazonaws.com";
-    private static final Region REGION = Region.US_WEST_2;
+    AmazonOpenSearchServiceSample(final String[] args) throws ParseException {
+        super("es", args);
+    }
 
     /**
      *
      * @param args
      * @throws IOException
+     * @throws ParseException
      */
-    public static void main(final String[] args) throws IOException {
-        AmazonOpenSearchServiceSample sample = new AmazonOpenSearchServiceSample();
+    public static void main(final String[] args) throws IOException, ParseException {
+        AmazonOpenSearchServiceSample sample = new AmazonOpenSearchServiceSample(args);
         sample.makeRequest();
         sample.indexDocument();
         sample.indexDocumentWithCompressionEnabled();
@@ -82,30 +83,29 @@ public class AmazonOpenSearchServiceSample extends Sample {
     }
 
     private void makeRequest() throws IOException {
-        HttpGet httpGet = new HttpGet(ENDPOINT);
-        logRequest("es", REGION, httpGet);
+        logRequest(new HttpGet(endpoint));
     }
 
     private void indexDocument() throws IOException {
         String payload = "{\"test\": \"val\"}";
-        HttpPost httpPost = new HttpPost(ENDPOINT + "/index_name/type_name/document_id");
+        HttpPost httpPost = new HttpPost(endpoint + "/index_name/type_name/document_id");
         httpPost.setEntity(new StringEntity(payload));
         httpPost.addHeader("Content-Type", "application/json");
-        logRequest("es", REGION, httpPost);
+        logRequest(httpPost);
     }
 
     private void indexDocumentWithChunkedTransferEncoding() throws IOException {
         String payload = "{\"test\": \"val\"}";
-        HttpPost httpPost = new HttpPost(ENDPOINT + "/index_name/type_name/document_id");
+        HttpPost httpPost = new HttpPost(endpoint + "/index_name/type_name/document_id");
         StringEntity entity = new StringEntity(payload);
         entity.setChunked(true);
         httpPost.setEntity(entity);
         httpPost.addHeader("Content-Type", "application/json");
-        logRequest("es", REGION, httpPost);
+        logRequest(httpPost);
     }
 
     private void indexDocumentWithCompressionEnabled() throws IOException {
-        HttpPost httpPost = new HttpPost(ENDPOINT + "/index_name/type_name/document_id");
+        HttpPost httpPost = new HttpPost(endpoint + "/index_name/type_name/document_id");
         httpPost.setHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
         httpPost.addHeader("Content-Type", "application/json");
         String payload = "{\"test\": \"val\"}";
@@ -117,17 +117,17 @@ public class AmazonOpenSearchServiceSample extends Sample {
         ByteArrayEntity entity = new ByteArrayEntity(outputStream.toByteArray(), ContentType.DEFAULT_BINARY);
         entity.setContentEncoding("gzip");
         httpPost.setEntity(entity);
-        logRequest("es", REGION, httpPost);
+        logRequest(httpPost);
     }
 
     private void indexDocumentWithChunkedTransferEncodingCompressionEnabled() throws IOException {
-        HttpPost httpPost = new HttpPost(ENDPOINT + "/index_name/type_name/document_id");
+        HttpPost httpPost = new HttpPost(endpoint + "/index_name/type_name/document_id");
         httpPost.setHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
         httpPost.addHeader("Content-Type", "application/json");
         String payload = "{\"test\": \"val\"}";
         // chunked by default
         GzipCompressingEntity entity = new GzipCompressingEntity(new StringEntity(payload));
         httpPost.setEntity(entity);
-        logRequest("es", REGION, httpPost);
+        logRequest(httpPost);
     }
 }


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

This is the beginning of https://github.com/acm19/aws-request-signing-apache-interceptor/issues/40, enabling us to run samples against any endpoint without modifying source code. I'm thinking that if we have a stable AWS service we can talk to in integration tests, we can just run samples against it.

```
mvn test-compile exec:java -Dexec.classpathScope=test -Dexec.mainClass="io.github.acm19.aws.interceptor.test.AmazonOpenSearchServiceSample" -Dexec.args="--endpoint=https://search-dblock-test-opensearch-21-tu5gqrjd4vg4qazjsu6bps5zsy.us-west-2.es.amazonaws.com --region=us-west-2"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
