### PR TITLE
Fix release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.1.0 (Next)
 
+* [#58](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/58): Test and fix Maven Central - [@acm19](https://github.com/acm19).
 * [#59](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/59): Document versioning standard - [@acm19](https://github.com/acm19).
 * [#44](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/44): Release to Maven Central - [@dblock](https://github.com/dblock), [@acm19](https://github.com/acm19).
 * [#42](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/42): Add editorconfig - [@acm19](https://github.com/acm19).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.1.0 (Next)
 
-* [#58](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/58): Test and fix Maven Central - [@acm19](https://github.com/acm19).
+* [#58](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/58): Test and fix the release process - [@acm19](https://github.com/acm19).
 * [#59](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/59): Document versioning standard - [@acm19](https://github.com/acm19).
 * [#44](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/44): Release to Maven Central - [@dblock](https://github.com/dblock), [@acm19](https://github.com/acm19).
 * [#42](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/42): Add editorconfig - [@acm19](https://github.com/acm19).

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,17 @@ release: checkout_master verify create_release prepare_next_development_version 
 .PHONY: checkout_master
 .SILENT: checkout_master
 checkout_master:
-	git checkout master && \
+	git checkout master
 	git pull
 
 .PHONY: create_release
 .SILENT: create_release
 create_release: set_release_version update_release_files_and_commit
 
-.PHONY: create_release
-.SILENT: create_release
+.PHONY: set_release_version
+.SILENT: set_release_version
 set_release_version:
-	git checkout -b $(RELEASE_BRANCH) && \
+	git checkout -b $(RELEASE_BRANCH)
 	mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
 	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.incrementalVersion\}
 
@@ -27,9 +27,9 @@ set_release_version:
 .SILENT: update_release_files_and_commit
 update_release_files_and_commit:
 	DATE=$$(date +%Y\\/%m\\/%d) && \
-	sed -i -E "1 s/\\s+\\(Next\\)\s*$$/ \\($$DATE\\)/" CHANGELOG.md && \
-	git add pom.xml CHANGELOG.md && \
-	git commit -m "Release version $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" && \
+	sed -i -E "1 s/\\s+\\(Next\\)\s*$$/ \\($$DATE\\)/" CHANGELOG.md
+	git add pom.xml CHANGELOG.md
+	git commit -m "Release version $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 	git push $(REMOTE) $(RELEASE_BRANCH)
 
 .PHONY: prepare_next_development_version
@@ -39,28 +39,28 @@ prepare_next_development_version: set_next_development_version update_developmen
 .PHONY: set_next_development_version
 .SILENT: set_next_development_version
 set_next_development_version:
-	git checkout -b $(SNAPSHOT_BRANCH) && \
+	git checkout -b $(SNAPSHOT_BRANCH)
 	mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
 	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.nextIncrementalVersion\}-SNAPSHOT
 
 .PHONY: update_development_files_and_commit
 .SILENT: update_development_files_and_commit
 update_development_files_and_commit:
-	sed -i "1 s/^/### $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout) \(Next\)\\n\\n/" CHANGELOG.md && \
-	git add pom.xml CHANGELOG.md && \
-	git commit -m "Prepare for next development iteration $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" && \
+	sed -i "1 s/^/### $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout) \(Next\)\\n\\n/" CHANGELOG.md
+	git add pom.xml CHANGELOG.md
+	git commit -m "Prepare for next development iteration $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 	git push $(REMOTE) $(SNAPSHOT_BRANCH)
 
 .PHONY: create_pull_requests
 .SILENT: create_pull_requests
 create_pull_requests:
-	gh pr create --base "master" --fill --head $(RELEASE_BRANCH) --title "Release library" && \
+	gh pr create --base "master" --fill --head $(RELEASE_BRANCH) --title "Release library"
 	gh pr create --base "master" --fill --head $(SNAPSHOT_BRANCH) --title "Prepare for next development iteration after release" --draft
 
 .PHONY: cleanup_local_branches
 .SILENT: cleanup_local_branches
 cleanup_local_branches:
-	git checkout master && \
+	git checkout master
 	git branch -D $(SNAPSHOT_BRANCH) $(RELEASE_BRANCH)
 
 .PHONY: verify

--- a/Makefile
+++ b/Makefile
@@ -14,25 +14,42 @@ checkout_master:
 
 .PHONY: create_release
 .SILENT: create_release
-create_release:
+create_release: set_release_version update_release_files_and_commit
+
+.PHONY: create_release
+.SILENT: create_release
+set_release_version:
 	git checkout -b $(RELEASE_BRANCH) && \
 	mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
-	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.incrementalVersion\} && \
-	sed -i -E "1 s/\\s+\\(Next\\)\s*$$//" CHANGELOG.md && \
+	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.incrementalVersion\}
+
+.PHONY: update_release_files_and_commit
+.SILENT: update_release_files_and_commit
+update_release_files_and_commit:
+	DATE=$$(date +%Y\\/%m\\/%d) && \
+	sed -i -E "1 s/\\s+\\(Next\\)\s*$$/ \\($$DATE\\)/" CHANGELOG.md && \
 	git add pom.xml CHANGELOG.md && \
 	git commit -m "Release version $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" && \
 	git push $(REMOTE) $(RELEASE_BRANCH)
 
 .PHONY: prepare_next_development_version
 .SILENT: prepare_next_development_version
-prepare_next_development_version:
+prepare_next_development_version: set_next_development_version update_development_files_and_commit
+
+.PHONY: set_next_development_version
+.SILENT: set_next_development_version
+set_next_development_version:
 	git checkout -b $(SNAPSHOT_BRANCH) && \
 	mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
-	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.nextIncrementalVersion\}-SNAPSHOT && \
+	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.nextIncrementalVersion\}-SNAPSHOT
+
+.PHONY: update_development_files_and_commit
+.SILENT: update_development_files_and_commit
+update_development_files_and_commit:
 	sed -i "1 s/^/### $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout) \(Next\)\\n\\n/" CHANGELOG.md && \
 	git add pom.xml CHANGELOG.md && \
 	git commit -m "Prepare for next development iteration $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" && \
-	git push $(REMOTE) $(RELEASE_BRANCH)
+	git push $(REMOTE) $(SNAPSHOT_BRANCH)
 
 .PHONY: create_pull_requests
 .SILENT: create_pull_requests
@@ -43,6 +60,7 @@ create_pull_requests:
 .PHONY: cleanup_local_branches
 .SILENT: cleanup_local_branches
 cleanup_local_branches:
+	git checkout master && \
 	git branch -D $(SNAPSHOT_BRANCH) $(RELEASE_BRANCH)
 
 .PHONY: verify


### PR DESCRIPTION
Fixes minor errors in the release process. Including pushing release
branch twice and not pushing snapshot image.

Fixes versions not properly set because of Makefile expansion of
variables before running rules. Separatating in 2 different rules fixes
the problems.

*Issue #, if available:* https://github.com/acm19/aws-request-signing-apache-interceptor/issues/35

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
