### PR TITLE
Standardise versioning numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.1.0 (Next)
 
+* [#59](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/59): Document versioning standard - [@acm19](https://github.com/acm19).
 * [#44](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/44): Release to Maven Central - [@dblock](https://github.com/dblock), [@acm19](https://github.com/acm19).
 * [#42](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/42): Add editorconfig - [@acm19](https://github.com/acm19).
 * [#45](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/45): Updating copyright to include contributors - [@dblock](https://github.com/dblock).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,10 +17,23 @@ Go the project root directory and run
 make release
 ```
 
-> **_NOTE:_** If you are not a maintainer, you might want to set the `REMOTE` env variable to your preferred remote name. The `create_pull_requests` target might fail and you will need to create the PRs manually from the branches that were pushed.
+> **_NOTE:_** If you are not a maintainer, you might want to set the `REMOTE` env variable to your preferred remote name. The `create_pull_requests` target might fail, then you will need to create the PRs manually from the branches that were pushed.
 
 ### For Maintainers
 
-Once a release is prepared 2 Pull Request will be generated. They have to be merged in order. First the one for the release and then the one for the next development version (it should be a draft PR). The automation will take care of the rest.
+Once a release is prepared 2 pull requests will be generated. They have to be merged in order. First the one for the release and then the one for the next development version (it should be a draft PR). The automation will take care of the rest.
 
 > **_NOTE:_** Please review the changes in case there are errors if the PR were modified after the automation ran.
+
+#### Versioning
+
+This project follows [Semantic Versioning 2.0.0 (semver)](https://semver.org/spec/v2.0.0.html).
+
+> **_NOTE:_** It's responsibility of the committer to update the version number within the same pull request where the change was introduced when the changes affect `minor` or `major` as follows:
+
+Given a version number MAJOR.MINOR.PATCH, increment the:
+
+* `MAJOR` version when you make incompatible API changes,
+* `MINOR` version when you add functionality in a backwards compatible manner, and
+* `PATCH` version when you make backwards compatible bug fixes.
+


### PR DESCRIPTION
Documents standard for version numbers and how the should be updated.

Resolves: https://github.com/acm19/aws-request-signing-apache-interceptor/issues/49

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
