### PR TITLE
Add required POM fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 2.1.1-SNAPSHOT (Next)
 
+* [#67](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/67): Add fields required by Maven Central to de POM - [@acm19](https://github.com/acm19).
+
 ### 2.1.0 (2022/07/12)
 
 * [#58](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/58): Test and fix the release process - [@acm19](https://github.com/acm19).

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,12 @@
   <version>2.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <name>AWS Request Signing Apache Interceptor</name>
+  <description>
+    This library enables signing requests to any service that leverages SigV4,
+    and thus access any AWS Service or APIG-backed service.
+  </description>
+  <url>https://github.com/acm19/aws-request-signing-apache-interceptor</url>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -14,6 +20,17 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <name>acm19</name>
+      <email>acm19@users.noreply.github.com</email>
+    </developer>
+    <developer>
+      <name>Daniel Doubrovkine</name>
+      <email>dblock@dblock.org</email>
+    </developer>
+  </developers>
 
   <scm>
     <url>https://github.com/acm19/aws-request-signing-apache-interceptor</url>


### PR DESCRIPTION
Adds required POM fields by Maven Central. Error returned by their
check:

> Invalid POM: Project name missing, Project description missing, Project
> URL missing, Developer information missing

Resolves: https://github.com/acm19/aws-request-signing-apache-interceptor/issues/65

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
