### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,54 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+  release:
+    name: Prepare release
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PUSH_TOKEN }}
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+      - name: Set release version
+        run: |
+            mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
+              -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion}
+      - name: Update files for release
+        run: |
+            DATE=$(date +%Y/%m/%d)
+            sed -i -E "1 s|\s+\(Next\)\s*\$| \($DATE\)|" CHANGELOG.md
+            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            sed -i -E "s|<version>.*</version>|<version>$VERSION</version>|" README.md
+      - name: Commit release and push
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Release version $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          git push
+      - name: Set development version
+        run: |
+          mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
+            -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT
+      - name: Update files for development
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | cut -d- -f1)
+          sed -i "1 s/^/### $VERSION \(Next\)\n\n/" CHANGELOG.md
+      - name: Commit snapshot and push
+        run: |
+          git add pom.xml CHANGELOG.md
+          git commit -m "Prepare for next development iteration $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          git push

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Deploy to Maven
+name: Publish Release
 
 on:
   push:
@@ -6,11 +6,15 @@ on:
       - master
 
 jobs:
-  build:
+  test:
+    uses: ./.github/workflows/test.yml
+  publish:
     name: Build project and deploy
+    needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout the repository
+      uses: actions/checkout@v3
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
@@ -34,7 +38,7 @@ jobs:
         MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-    - name: Create Release
+    - name: Create Release Tag
       if: ${{ !endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
-name: Execute Java tests
-on: [push, pull_request]
+name: Execute Java Tests
+on:
+  pull_request:
+  workflow_call:
+  push:
+    branches-ignore:
+      - master
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.1.2 (Next)
 
+* [#76](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/76): Automate release process - [@acm19](https://github.com/acm19).
 * [#75](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/75): Add OpenSearch cluster infrastructure - [@acm19](https://github.com/acm19).
 * [#72](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/72): Add running sample recipe - [@acm19](https://github.com/acm19).
 * [#71](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/71): Add commit message convention - [@acm19](https://github.com/acm19).

--- a/Makefile
+++ b/Makefile
@@ -1,84 +1,10 @@
 REGION?=us-east-1
 ENDPOINT?=http://my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566
 
-RELEASE_BRANCH?=release
-SNAPSHOT_BRANCH?=snapshot
-REMOTE?=origin
-
-.PHONY: release
-.SILENT: release
-release: checkout_master verify create_release prepare_next_development_version create_pull_requests cleanup_local_branches
-
-.PHONY: checkout_master
-.SILENT: checkout_master
-checkout_master:
-	git checkout master
-	git pull
-
-.PHONY: create_release
-.SILENT: create_release
-create_release: set_release_version update_release_files_and_commit
-
-.PHONY: set_release_version
-.SILENT: set_release_version
-set_release_version:
-	git checkout -b $(RELEASE_BRANCH)
-	mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
-	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.incrementalVersion\}
-
-.PHONY: update_release_files_and_commit
-.SILENT: update_release_files_and_commit
-update_release_files_and_commit:
-	DATE=$$(date +%Y\\/%m\\/%d) && \
-	sed -i -E "1 s/\\s+\\(Next\\)\s*$$/ \\($$DATE\\)/" CHANGELOG.md
-	VERSION=$(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout) && \
-	sed -i -E "s|<version>.*<\/version>|<version>$$VERSION</version>|" README.md && \
-	git add pom.xml CHANGELOG.md README.md && \
-	git commit -m "Release version $$VERSION"
-	git push $(REMOTE) $(RELEASE_BRANCH)
-
-.PHONY: prepare_next_development_version
-.SILENT: prepare_next_development_version
-prepare_next_development_version: set_next_development_version update_development_files_and_commit
-
-.PHONY: set_next_development_version
-.SILENT: set_next_development_version
-set_next_development_version:
-	git checkout -b $(SNAPSHOT_BRANCH)
-	mvn build-helper:parse-version versions:set -DgenerateBackupPoms=false \
-	 -DnewVersion=$$\{parsedVersion.majorVersion\}.$$\{parsedVersion.minorVersion\}.$$\{parsedVersion.nextIncrementalVersion\}-SNAPSHOT
-
-.PHONY: update_development_files_and_commit
-.SILENT: update_development_files_and_commit
-update_development_files_and_commit:
-	VERSION=$(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout | cut -d- -f1) && \
-	sed -i "1 s/^/### $$VERSION \(Next\)\\n\\n/" CHANGELOG.md && \
-	git add pom.xml CHANGELOG.md && \
-	git commit -m "Prepare for next development iteration $$VERSION"
-	git push $(REMOTE) $(SNAPSHOT_BRANCH)
-
-.PHONY: create_pull_requests
-.SILENT: create_pull_requests
-create_pull_requests:
-	gh pr create --base "master" --fill --head $(RELEASE_BRANCH) --title "Release library"
-	gh pr create --base "master" --fill --head $(SNAPSHOT_BRANCH) --title "Prepare for next development iteration after release" --draft
-
-.PHONY: cleanup_local_branches
-.SILENT: cleanup_local_branches
-cleanup_local_branches:
-	git checkout master
-	git branch -D $(SNAPSHOT_BRANCH) $(RELEASE_BRANCH)
-
 .PHONY: verify
 .SILENT: verify
 verify:
 	mvn clean verify
-
-.PHONY: validate_branch_dont_exist
-.SILENT: validate_branch_dont_exist
-validate_branch_dont_exist:
-	git branch | grep -Eq "$(RELEASE_BRANCH)|$(SNAPSHOT_BRANCH)" && exit 2 || \
-	git remote show $(REMOTE) | grep -Eq "$(RELEASE_BRANCH)|$(SNAPSHOT_BRANCH)" && exit 2 || true
 
 .PHONY: run_sample
 .SILENT: run_sample

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,28 +2,9 @@
 
 There are no hard rules about when to release `aws-request-signing-apache-interceptor`. Release bug fixes frequently, features not so frequently and breaking API changes rarely.
 
-### Requirements
-
-Apart from the obvious programs that you need to build and run the project locally: Git, Maven, Java, etc. You will need:
-* [GitHub CLI](https://cli.github.com/).
-* [GNU make](https://www.gnu.org/software/make/manual/make.html).
-* [GNU sed](https://www.gnu.org/software/sed/).
-
-### Release
-
-Go the project root directory and run
-
-```
-make release
-```
-
-> **_NOTE:_** If you are not a maintainer, you might want to set the `REMOTE` env variable to your preferred remote name. The `create_pull_requests` target might fail, then you will need to create the PRs manually from the branches that were pushed.
-
 ### For Maintainers
 
-Once a release is prepared 2 pull requests will be generated. They have to be merged in order. First the one for the release and then the one for the next development version (it should be a draft PR). The automation will take care of the rest.
-
-> **_NOTE:_** Please review the changes in case there are errors if the PR were modified after the automation ran.
+To release manually run `Prepare Release` in the `master` branch. Make sure no commits are pushed to `master` during the time this job is running to avoid race conditions.
 
 #### Versioning
 
@@ -31,7 +12,7 @@ This project follows [Semantic Versioning 2.0.0 (semver)](https://semver.org/spe
 
 > **_NOTE:_** It's responsibility of the committer to update the version number within the same pull request where the change was introduced when the changes affect `minor` or `major` as follows:
 
-Given a version number MAJOR.MINOR.PATCH, increment the:
+Given a version number `MAJOR.MINOR.PATCH`, increment the:
 
 * `MAJOR` version when you make incompatible API changes,
 * `MINOR` version when you add functionality in a backwards compatible manner, and


### PR DESCRIPTION
Fully automates the release process by moving from a Makefile that had
to be executed locally to a job that is triggered in GitHub. This
removes possible errors and manual burden associated to releasing.

The new process skips the creation of intermediate branches and pull
requests and commits directly to master, which then triggers the
actual pushing of the artefacts together with the tagging of the repo
the same way it was done before this change.

Resolves: https://github.com/acm19/aws-request-signing-apache-interceptor/issues/53

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
