### PR TITLE
Make samples compatible with OpenSearch 2.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 2.2.1 (Next)
 
+* [#92](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/92): Make samples compatible with OpenSearch 2.x - [@dblock](https://github.com/dblock).
+
 ### 2.2.0 (2022/10/02)
 
 * [#80](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/80): Add support for Apache client v5 - [@acm19](https://github.com/acm19).


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

- Use `_doc` that works on both 1.x and 2.x versions.
- Create a delete the index. Not really required but good to cleanup.

Closes #91. 

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
