### PR TITLE
Make request interceptors simpler and other improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run tests with Maven
         run: mvn --batch-mode verify
       - name: Validate checkstyle
-        run: mvn validate -Pcheckstyle
+        run: mvn --batch-mode validate -Pcheckstyle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 2.3.1 (Next)
+* [#104](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/104): Make request interceptors simpler and other improvements - [@acm19](https://github.com/acm19).
 
 ### 2.3.0 (2023/01/26)
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,17 @@ SERVICE?=es
 .PHONY: verify
 .SILENT: verify
 verify:
-	mvn clean verify
+	mvn verify
+
+
+.PHONY: checkstyle
+.SILENT: checkstyle
+checkstyle:
+	mvn validate -Pcheckstyle
+
+.PHONY: run_all_samples
+.SILENT: run_all_samples
+run_all_samples: run_sample run_v5_sample
 
 .PHONY: run_sample
 .SILENT: run_sample

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ To sign requests made with pre-5 versions of the clients the following intercept
 import java.io.IOException;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -52,9 +51,10 @@ final class Example {
                 .addInterceptorLast(interceptor)
                 .build()) {
             HttpGet httpGet = new HttpGet("https://...");
-            CloseableHttpResponse response = client.execute(httpGet);
-            System.out.println(response.getStatusLine());
-            System.out.println(IoUtils.toUtf8String(response.getEntity().getContent()));
+            httpClient.execute(request, response -> {
+                System.out.println(response.getStatusLine());
+                System.out.println(IoUtils.toUtf8String(response.getEntity().getContent()));
+            });
         }
     }
 }
@@ -70,7 +70,6 @@ import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheV5Interceptor
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -91,9 +90,10 @@ final class Example {
                 .addRequestInterceptorLast(interceptor)
                 .build()) {
             HttpGet httpGet = new HttpGet("https://...");
-            CloseableHttpResponse response = client.execute(httpGet);
-            System.out.println(response.getCode());
-            System.out.println(IoUtils.toUtf8String(response.getEntity().getContent()));
+            httpClient.execute(request, response -> {
+                System.out.println(response.getCode());
+                System.out.println(IoUtils.toUtf8String(response.getEntity().getContent()));
+            });
         }
     }
 }

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -159,7 +159,6 @@
 
     <!-- See https://checkstyle.org/config_misc.html -->
     <module name="ArrayTypeStyle"/>
-    <module name="FinalParameters"/>
     <module name="TodoComment"/>
     <module name="UpperEll"/>
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,45 +1,37 @@
 BOOTSTRAP_STACK_NAME?=CDKToolkit
 
-.SILENT: venv
 venv:
 	python3 -m venv venv
 	. venv/bin/activate && \
 	pip install -r requirements.txt
 
 .PHONY: clean
-.SILENT: clean
 clean:
-	rm -rf venv
+	rm -rf venv node_modules
 
-.SILENT: node_modules
 node_modules:
 	npm install
 
 .PHONY: synth
-.SILENT: synth
 synth: node_modules
 	./node_modules/.bin/cdk synth --path-metadata false
 
 .PHONY: bootstrap
-.SILENT: bootstrap
 bootstrap: node_modules venv
 	. venv/bin/activate && \
 	./node_modules/.bin/cdk bootstrap
 
 .PHONY: deploy
-.SILENT: deploy
 deploy: node_modules venv
 	. venv/bin/activate && \
 	./node_modules/.bin/cdk deploy --path-metadata false
 
 .PHONY: destroy
-.SILENT: destroy
 destroy:
 	. venv/bin/activate && \
 	./node_modules/.bin/cdk destroy
 
 .PHONY: destroy_all
-.SILENT: destroy_all
 destroy_all: node_modules destroy
 	./node_modules/.bin/cdk ls > /dev/null 2>&1 || (echo "Being in Virtual Env is necessary to run this target"; exit 1)
 	BUCKET_NAME=$$(aws cloudformation describe-stacks --stack-name $(BOOTSTRAP_STACK_NAME) --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output=text); \

--- a/infra/opensearch_cluster/opensearch_cluster.py
+++ b/infra/opensearch_cluster/opensearch_cluster.py
@@ -10,7 +10,7 @@ class OpenSearchStack(Stack):
 
         open_search_cluster = aws_opensearchservice.Domain(self,
                                                            "InterceptorTest",
-                                                           version=EngineVersion.OPENSEARCH_2_3,
+                                                           version=EngineVersion.OPENSEARCH_2_5,
                                                            capacity=aws_opensearchservice.CapacityConfig(
                                                                data_node_instance_type="t3.small.search"
                                                            ),

--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.72.1
+aws-cdk-lib==2.80.0
 constructs==10.1.299
 types-setuptools==67.6.0.6

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-        <version>2.20.37</version>
+        <version>2.20.73</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/io/github/acm19/aws/interceptor/http/RequestSigner.java
+++ b/src/main/java/io/github/acm19/aws/interceptor/http/RequestSigner.java
@@ -48,10 +48,10 @@ class RequestSigner {
      * @param awsCredentialsProvider
      * @param region
      */
-    RequestSigner(final String service,
-                         final Signer signer,
-                         final AwsCredentialsProvider awsCredentialsProvider,
-                         final Region region) {
+    RequestSigner(String service,
+                  Signer signer,
+                  AwsCredentialsProvider awsCredentialsProvider,
+                  Region region) {
         this.service = service;
         this.signer = signer;
         this.awsCredentialsProvider = awsCredentialsProvider;
@@ -67,7 +67,7 @@ class RequestSigner {
      * @return signed request
      * @see Signer#sign
      */
-    SdkHttpFullRequest signRequest(final SdkHttpFullRequest request) {
+    SdkHttpFullRequest signRequest(SdkHttpFullRequest request) {
         ExecutionAttributes attributes = new ExecutionAttributes();
         attributes.putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS,
                                 awsCredentialsProvider.resolveCredentials());
@@ -86,7 +86,7 @@ class RequestSigner {
      * @return an {@link URI} from an HTTP context
      * @throws IOException if the {@code uri} syntax is invalid
      */
-    static URI buildUri(final HttpContext context, final String uri) throws IOException {
+    static URI buildUri(HttpContext context, String uri) throws IOException {
         try {
             URIBuilder uriBuilder = new URIBuilder(uri);
 

--- a/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
@@ -62,8 +62,8 @@ import org.apache.http.entity.StringEntity;
  *                 .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
  * </pre>
  */
-public class AmazonOpenSearchServiceSample extends Sample {
-    AmazonOpenSearchServiceSample(final String[] args) throws ParseException {
+public final class AmazonOpenSearchServiceSample extends Sample {
+    private AmazonOpenSearchServiceSample(final String[] args) throws ParseException {
         super(args);
     }
 

--- a/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
@@ -20,7 +20,6 @@ import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -104,17 +103,18 @@ class Sample {
         System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
         System.setProperty("org.apache.commons.logging.simplelog.showdatetime", "true");
         System.setProperty("org.apache.commons.logging.simplelog.log.org.apache.http.wire", "DEBUG");
-        CloseableHttpClient httpClient = signingClient();
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            System.out.println(response.getStatusLine());
-            System.out.println(IoUtils.toUtf8String(response.getEntity().getContent()));
-            switch (response.getStatusLine().getStatusCode()) {
-                case HttpStatus.SC_OK:
-                case HttpStatus.SC_CREATED:
-                    break;
-                default:
-                    throw new RuntimeException(response.getStatusLine().getReasonPhrase());
-            }
+        try (CloseableHttpClient httpClient = signingClient()) {
+            httpClient.execute(request, response -> {
+                System.out.println(response.getStatusLine());
+                System.out.println(IoUtils.toUtf8String(response.getEntity().getContent()));
+                switch (response.getStatusLine().getStatusCode()) {
+                    case HttpStatus.SC_OK:
+                    case HttpStatus.SC_CREATED:
+                        return true;
+                    default:
+                        throw new RuntimeException(response.getStatusLine().getReasonPhrase());
+                }
+            });
         }
     }
 

--- a/src/test/java/io/github/acm19/aws/interceptorv5/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptorv5/test/AmazonOpenSearchServiceSample.java
@@ -12,6 +12,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.cli.ParseException;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -60,8 +62,8 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
  *                 .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
  * </pre>
  */
-public class AmazonOpenSearchServiceSample extends Sample {
-    AmazonOpenSearchServiceSample(final String[] args) throws ParseException {
+public final class AmazonOpenSearchServiceSample extends Sample {
+    private AmazonOpenSearchServiceSample(String[] args) throws ParseException {
         super(args);
     }
 
@@ -71,13 +73,15 @@ public class AmazonOpenSearchServiceSample extends Sample {
      * @throws IOException
      * @throws ParseException
      */
-    public static void main(final String[] args) throws IOException, ParseException {
+    public static void main(String[] args) throws IOException, ParseException {
         AmazonOpenSearchServiceSample sample = new AmazonOpenSearchServiceSample(args);
         sample.makeRequest();
         sample.createIndex();
         try {
             sample.indexDocument();
             sample.indexDocumentWithCompressionEnabled();
+            // https://github.com/acm19/aws-request-signing-apache-interceptor/issues/101
+            // sample.indexDocumentAsynchronously();
             // https://github.com/acm19/aws-request-signing-apache-interceptor/issues/20
             // sample.indexDocumentWithChunkedTransferEncoding();
             // sample.indexDocumentWithChunkedTransferEncodingCompressionEnabled();
@@ -147,5 +151,15 @@ public class AmazonOpenSearchServiceSample extends Sample {
         GzipCompressingEntity entity = new GzipCompressingEntity(new StringEntity(payload));
         httpPost.setEntity(entity);
         logRequest(httpPost);
+    }
+
+    private void indexDocumentAsynchronously() throws IOException {
+        String payload = "{\"test\": \"ayncVal\"}";
+        SimpleHttpRequest httpPost = SimpleRequestBuilder.post()
+                .setUri(endpoint + "/index_name/_doc")
+                .setBody(payload, ContentType.APPLICATION_JSON)
+                .build();
+
+        logAsyncRequest(httpPost);
     }
 }


### PR DESCRIPTION
Reduces code in the interceptor by setting back the body at the same time it's retrieve. Since the body is not modified during the signing process it's not necessary to have the same conditions twice in the code.

Removes check for `final` parameters as it mostly makes the code more verbose and it helps very little in such a small library.

Removes use of deprecated `httpClient.execute` methods replacing it by the currently supported versions of the same method, updates the documentation accordingly.

Bumps the version of the testing OpenSearch cluster to 2.5.

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
