### PR TITLE
Enforce stricter TODO comments checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 2.3.1 (Next)
+* [#106](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/106): Enforce stricter TODO comments checks - [@acm19](https://github.com/acm19).
 * [#104](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/104): Make request interceptors simpler and other improvements - [@acm19](https://github.com/acm19).
 
 ### 2.3.0 (2023/01/26)

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -159,7 +159,9 @@
 
     <!-- See https://checkstyle.org/config_misc.html -->
     <module name="ArrayTypeStyle"/>
-    <module name="TodoComment"/>
+    <module name="TodoComment">
+      <property name="format" value="([Tt][Oo][Dd][Oo])|([Ff][Ii][Xx][Mm][Ee])"/>
+    </module>
     <module name="UpperEll"/>
 
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->

--- a/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
@@ -89,7 +89,8 @@ public final class AmazonOpenSearchServiceSample extends Sample {
     }
 
     private void makeRequest() throws IOException {
-        // todo: https://github.com/acm19/aws-request-signing-apache-interceptor/issues/95
+        // Remove when GET support is added to OpenSearch Serverless:
+        // https://github.com/acm19/aws-request-signing-apache-interceptor/issues/95
         if (!service.equals("aoss")) {
             logRequest(new HttpGet(endpoint));
         }

--- a/src/test/java/io/github/acm19/aws/interceptorv5/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptorv5/test/AmazonOpenSearchServiceSample.java
@@ -104,7 +104,8 @@ public final class AmazonOpenSearchServiceSample extends Sample {
     }
 
     private void makeRequest() throws IOException {
-        // todo: https://github.com/acm19/aws-request-signing-apache-interceptor/issues/95
+        // Remove when GET support is added to OpenSearch Serverless:
+        // https://github.com/acm19/aws-request-signing-apache-interceptor/issues/95
         if (!service.equals("aoss")) {
             logRequest(new HttpGet(endpoint));
         }


### PR DESCRIPTION
Improves todo check regex by checking for it case insensitive. Adds checks for fixme case insensitive as well.

Resolves: https://github.com/acm19/aws-request-signing-apache-interceptor/issues/96

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
