### PR TITLE
Replace Aws4Signer with AwsV4HttpSigner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-### 2.3.2 (Next)
+### 3.0.0 (Next)
+* [#125](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/125): Use to use `AwsV4HttpSigner` - [@GeorgeVincentDepop](https://github.com/GeorgeVincentDepop)
 
 ### 2.3.1 (2023/06/11)
 * [#107](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/107): Automate the release fully by auto closing it - [@acm19](https://github.com/acm19).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheInterceptor;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.IoUtils;
 
@@ -42,7 +42,7 @@ final class Example {
     public static void main(String[] args) throws ClientProtocolException, IOException {
         HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(
                 "service",
-                Aws4Signer.create(),
+                AwsV4HttpSigner.create(),
                 DefaultCredentialsProvider.create(),
                 Region.US_WEST_2
         );
@@ -73,7 +73,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.IoUtils;
 
@@ -81,7 +81,7 @@ final class Example {
     public static void main(String[] args) throws ClientProtocolException, IOException {
         HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
                 "service",
-                Aws4Signer.create(),
+                AwsV4HttpSigner.create(),
                 DefaultCredentialsProvider.create(),
                 Region.US_WEST_2
         );

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,58 @@
+- [Upgrading AWS Request Signing Interceptor](#upgrading-opensearch-python-client)
+    - [## Upgrading to >= 3.0.0](#upgrading-to->=-3.0.0)
+
+
+# Upgrading AWS Request Signing Interceptor
+
+## Upgrading to >= 3.0.0
+
+`Aws4Signer` has been deprecated in the AWS SDK for Java 2.0 and replaced with `AwsV4HttpSigner`.
+
+As a consequence, the `AwsRequestSigningApacheInterceptor` and `AwsRequestSigningApacheV5Interceptor` now requires an `AwsV4HttpSigner` instance instead of an `Aws4Signer`.
+
+To upgrade, replace the `Aws4Signer` with `AwsV4HttpSigner` in your code. For example, if you are using `AwsRequestSigningApacheInterceptor`:
+
+```java
+import java.io.IOException;
+import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheV5Interceptor;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.regions.Region;
+
+final class Example {
+    public static void main(String[] args) throws ClientProtocolException, IOException {
+        HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
+                "service",
+                Aws4Signer.create(),
+                DefaultCredentialsProvider.create(),
+                Region.US_WEST_2
+        );
+    }
+}
+```
+
+becomes:
+
+```java
+import java.io.IOException;
+import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheV5Interceptor;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.regions.Region;
+
+final class Example {
+    public static void main(String[] args) throws ClientProtocolException, IOException {
+        HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
+                "service",
+                AwsV4HttpSigner.create(),
+                DefaultCredentialsProvider.create(),
+                Region.US_WEST_2
+        );
+    }
+}
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.acm19</groupId>
   <artifactId>aws-request-signing-apache-interceptor</artifactId>
-  <version>2.3.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>AWS Request Signing Apache Interceptor</name>

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
 import java.util.zip.GZIPOutputStream;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHeaders;
@@ -37,10 +38,14 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.IoUtils;
 
@@ -163,8 +168,7 @@ class AwsRequestSigningApacheInterceptorTest {
             gzipOutputStream.write(data.getBytes("UTF-8"));
         }
 
-        ByteArrayEntity entity = new ByteArrayEntity(outputStream.toByteArray(),
-                ContentType.DEFAULT_BINARY);
+        ByteArrayEntity entity = new ByteArrayEntity(outputStream.toByteArray(), ContentType.DEFAULT_BINARY);
         entity.setContentEncoding("gzip");
         request.setHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
         request.setEntity(entity);
@@ -178,10 +182,12 @@ class AwsRequestSigningApacheInterceptorTest {
         assertEquals("required", request.getFirstHeader("x-amz-content-sha256").getValue());
 
         assertEquals(Long.toString(entity.getContentLength()),
-                request.getFirstHeader("signedContentLength").getValue());
+                    request.getFirstHeader("signedContentLength").getValue());
     }
 
-    private static final class AddHeaderSigner implements Signer {
+    private static final class AddHeaderSigner implements AwsV4HttpSigner {
+        AwsV4HttpSigner signer = new DefaultAwsV4HttpSigner();
+
         private final String name;
         private final String value;
 
@@ -191,22 +197,38 @@ class AwsRequestSigningApacheInterceptorTest {
         }
 
         @Override
-        public SdkHttpFullRequest sign(final SdkHttpFullRequest request, final ExecutionAttributes ea) {
-            SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder()
-                    .uri(request.getUri())
-                    .method(request.method())
-                    .headers(request.headers())
+        public SignedRequest sign(SignRequest signRequest) {
+            SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
+                    .uri(signRequest.request().getUri())
+                    .method(signRequest.request().method())
+                    .headers(signRequest.request().headers())
                     .appendHeader(name, value)
-                    .appendHeader("resourcePath", request.getUri().getRawPath());
+                    .appendHeader("resourcePath", signRequest.request().getUri().getRawPath());
 
-            if (request.contentStreamProvider().isPresent()) {
-                ContentStreamProvider contentStreamProvider = request.contentStreamProvider().get();
-                requestBuilder.contentStreamProvider(contentStreamProvider);
-                requestBuilder.appendHeader("signedContentLength",
-                        Long.toString(getContentLength(contentStreamProvider.newStream())));
+            if (signRequest.payload().isPresent()) {
+                ContentStreamProvider contentStreamProvider = (ContentStreamProvider) signRequest.payload().get();
+                InputStream payloadStream = contentStreamProvider.newStream();
+                ContentStreamProvider newContentStreamProvider = ContentStreamProvider.fromInputStream(payloadStream);
+
+                request.contentStreamProvider(newContentStreamProvider)
+                        .appendHeader("signedContentLength",
+                                Long.toString(getContentLength(newContentStreamProvider.newStream())))
+                        .build();
             }
 
-            return requestBuilder.build();
+            SdkHttpFullRequest requestBuilt = request.build();
+
+            SignedRequest signedRequest =
+                signer.sign(r -> r
+                        .identity(AnonymousCredentialsProvider.create().resolveCredentials())
+                        .request(requestBuilt)
+                        .payload(requestBuilt.contentStreamProvider().orElse(null))
+                        .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "servicename")
+                        .putProperty(AwsV4HttpSigner.REGION_NAME, "us-west-2")
+                        .putProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false) // Required for S3 only
+                        .putProperty(AwsV4HttpSigner.NORMALIZE_PATH, false)); // Required for S3 only
+
+            return signedRequest;
         }
 
         private static int getContentLength(final InputStream content) {
@@ -215,6 +237,11 @@ class AwsRequestSigningApacheInterceptorTest {
             } catch (IOException e) {
                 return -1;
             }
+        }
+
+        @Override
+        public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest asyncSignRequest) {
+            return null;
         }
     }
 

--- a/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/AmazonOpenSearchServiceSample.java
@@ -33,11 +33,10 @@ import org.apache.http.entity.StringEntity;
  * Example usage with the OpenSearch low-level REST client:
  *
  * <pre>
- * Aws4Signer signer = Aws4Signer.create();
  *
  * HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(
  *         "es",
- *         Aws4Signer.create(),
+ *         AwsV4HttpSigner.create(),
  *         DefaultCredentialsProvider.create(),
  *         "us-east-1");
  *
@@ -52,7 +51,7 @@ import org.apache.http.entity.StringEntity;
  * <pre>
  * HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(
  *         "es",
- *         Aws4Signer.create(),
+ *         AwsV4HttpSigner.create(),
  *         DefaultCredentialsProvider.create(),
  *         "us-east-1");
  *

--- a/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
@@ -28,7 +28,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheInterceptor;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.IoUtils;
 
@@ -121,7 +121,7 @@ class Sample {
     CloseableHttpClient signingClient() {
         HttpRequestInterceptor interceptor = new AwsRequestSigningApacheInterceptor(
                 service,
-                Aws4Signer.create(),
+                AwsV4HttpSigner.create(),
                 DefaultCredentialsProvider.create(),
                 region);
 

--- a/src/test/java/io/github/acm19/aws/interceptorv5/test/AmazonOpenSearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptorv5/test/AmazonOpenSearchServiceSample.java
@@ -37,7 +37,7 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
  * <pre>
  * HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
  *         "es",
- *         Aws4Signer.create(),
+ *         AwsV4HttpSigner.create(),
  *         DefaultCredentialsProvider.create(),
  *         "us-east-1");
  *
@@ -52,7 +52,7 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
  * <pre>
  * HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
  *         "es",
- *         Aws4Signer.create(),
+ *         AwsV4HttpSigner.create(),
  *         DefaultCredentialsProvider.create(),
  *         "us-east-1");
  *

--- a/src/test/java/io/github/acm19/aws/interceptorv5/test/Sample.java
+++ b/src/test/java/io/github/acm19/aws/interceptorv5/test/Sample.java
@@ -42,7 +42,7 @@ import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
 import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheV5Interceptor;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.regions.Region;
 
 class Sample {
@@ -139,7 +139,7 @@ class Sample {
     private CloseableHttpClient signingClient() {
         HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
                 service,
-                Aws4Signer.create(),
+                AwsV4HttpSigner.create(),
                 DefaultCredentialsProvider.create(),
                 region);
 
@@ -183,7 +183,7 @@ class Sample {
     private CloseableHttpAsyncClient signingAsyncClient() {
         HttpRequestInterceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
                 service,
-                Aws4Signer.create(),
+                AwsV4HttpSigner.create(),
                 DefaultCredentialsProvider.create(),
                 region);
 


### PR DESCRIPTION
*Description of changes:*

The library is currently using the deprecated `Aws4Signer`. This PR replaces the implementation with `AwsV4HttpSigner`

Resolves: [121](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/121)

### Pull Request Checklist:

- [X] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
