### PR TITLE
Dispatch/verify requests against mockwebserver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,13 @@
       <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- Capture real requests in test suite to verify signatures -->
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.12.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Provide wire logs for Apache Client v5 Sample -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AddHeaderSigner.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AddHeaderSigner.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The AWS Request Signing Interceptor Contributors require
+ * contributions made to this file be licensed under the
+ * Apache-2.0 license or a compatible open source license.
+ */
+
+package io.github.acm19.aws.interceptor.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
+import software.amazon.awssdk.utils.IoUtils;
+
+final class AddHeaderSigner implements AwsV4HttpSigner {
+    private final AwsV4HttpSigner signer = new DefaultAwsV4HttpSigner();
+
+    private final String name;
+    private final String value;
+
+    AddHeaderSigner(final String name, final String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public SignedRequest sign(SignRequest signRequest) {
+        SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
+                .uri(signRequest.request().getUri())
+                .method(signRequest.request().method())
+                .headers(signRequest.request().headers())
+                .appendHeader(name, value)
+                .appendHeader("resourcePath", signRequest.request().getUri().getRawPath());
+
+        if (signRequest.payload().isPresent()) {
+            ContentStreamProvider contentStreamProvider = (ContentStreamProvider) signRequest.payload().get();
+            InputStream payloadStream = contentStreamProvider.newStream();
+            ContentStreamProvider newContentStreamProvider = ContentStreamProvider.fromInputStream(payloadStream);
+
+            request.contentStreamProvider(newContentStreamProvider)
+                    .appendHeader("signedContentLength",
+                            Long.toString(getContentLength(newContentStreamProvider.newStream())))
+                    .build();
+        }
+
+        SdkHttpFullRequest requestBuilt = request.build();
+
+        SignedRequest signedRequest =
+            signer.sign(r -> r
+                    .identity(AnonymousCredentialsProvider.create().resolveCredentials())
+                    .request(requestBuilt)
+                    .payload(requestBuilt.contentStreamProvider().orElse(null))
+                    .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "servicename")
+                    .putProperty(AwsV4HttpSigner.REGION_NAME, "us-west-2")
+                    .putProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false) // Required for S3 only
+                    .putProperty(AwsV4HttpSigner.NORMALIZE_PATH, false)); // Required for S3 only
+
+        return signedRequest;
+    }
+
+    private static int getContentLength(final InputStream content) {
+        try {
+            return IoUtils.toByteArray(content).length;
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+
+    @Override
+    public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest asyncSignRequest) {
+        return null;
+    }
+}

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
@@ -22,8 +22,6 @@ import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.RequestLine;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
@@ -236,35 +234,6 @@ class AwsRequestSigningApacheInterceptorTest {
         @Override
         public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest asyncSignRequest) {
             return null;
-        }
-    }
-
-    private static class MockRequestLine implements RequestLine {
-        private final String uri;
-        private final String method;
-
-        MockRequestLine(final String uri) {
-            this("POST", uri);
-        }
-
-        MockRequestLine(final String method, final String uri) {
-            this.method = method;
-            this.uri = uri;
-        }
-
-        @Override
-        public String getMethod() {
-            return method;
-        }
-
-        @Override
-        public String getUri() {
-            return uri;
-        }
-
-        @Override
-        public ProtocolVersion getProtocolVersion() {
-            throw new UnsupportedOperationException("Not supported yet.");
         }
     }
 }

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
@@ -15,8 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
 import java.util.zip.GZIPOutputStream;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHeaders;
@@ -39,16 +37,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.http.ContentStreamProvider;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
-import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
-import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
-import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.utils.IoUtils;
 
 class AwsRequestSigningApacheInterceptorTest {
     private CloseableHttpClient client;
@@ -175,65 +164,5 @@ class AwsRequestSigningApacheInterceptorTest {
 
         assertEquals(Long.toString(entity.getContentLength()),
                     recorded.getHeader("signedContentLength"));
-    }
-
-    private static final class AddHeaderSigner implements AwsV4HttpSigner {
-        AwsV4HttpSigner signer = new DefaultAwsV4HttpSigner();
-
-        private final String name;
-        private final String value;
-
-        private AddHeaderSigner(final String name, final String value) {
-            this.name = name;
-            this.value = value;
-        }
-
-        @Override
-        public SignedRequest sign(SignRequest signRequest) {
-            SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
-                    .uri(signRequest.request().getUri())
-                    .method(signRequest.request().method())
-                    .headers(signRequest.request().headers())
-                    .appendHeader(name, value)
-                    .appendHeader("resourcePath", signRequest.request().getUri().getRawPath());
-
-            if (signRequest.payload().isPresent()) {
-                ContentStreamProvider contentStreamProvider = (ContentStreamProvider) signRequest.payload().get();
-                InputStream payloadStream = contentStreamProvider.newStream();
-                ContentStreamProvider newContentStreamProvider = ContentStreamProvider.fromInputStream(payloadStream);
-
-                request.contentStreamProvider(newContentStreamProvider)
-                        .appendHeader("signedContentLength",
-                                Long.toString(getContentLength(newContentStreamProvider.newStream())))
-                        .build();
-            }
-
-            SdkHttpFullRequest requestBuilt = request.build();
-
-            SignedRequest signedRequest =
-                signer.sign(r -> r
-                        .identity(AnonymousCredentialsProvider.create().resolveCredentials())
-                        .request(requestBuilt)
-                        .payload(requestBuilt.contentStreamProvider().orElse(null))
-                        .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "servicename")
-                        .putProperty(AwsV4HttpSigner.REGION_NAME, "us-west-2")
-                        .putProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false) // Required for S3 only
-                        .putProperty(AwsV4HttpSigner.NORMALIZE_PATH, false)); // Required for S3 only
-
-            return signedRequest;
-        }
-
-        private static int getContentLength(final InputStream content) {
-            try {
-                return IoUtils.toByteArray(content).length;
-            } catch (IOException e) {
-                return -1;
-            }
-        }
-
-        @Override
-        public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest asyncSignRequest) {
-            return null;
-        }
     }
 }

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5InterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5InterceptorTest.java
@@ -14,8 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
 import java.util.zip.GZIPOutputStream;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -36,16 +34,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.http.ContentStreamProvider;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.auth.aws.internal.signer.DefaultAwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
-import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
-import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
-import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.utils.IoUtils;
 
 class AwsRequestSigningApacheV5InterceptorTest {
     private static final BasicEntityDetails ENTITY_DETAILS = new BasicEntityDetails(0, ContentType.TEXT_XML);
@@ -150,67 +139,5 @@ class AwsRequestSigningApacheV5InterceptorTest {
 
         assertEquals(Long.toString(entity.getContentLength()),
                 recorded.getHeader("signedContentLength"));
-    }
-
-    private static final class AddHeaderSigner implements AwsV4HttpSigner {
-        private final AwsV4HttpSigner signer = new DefaultAwsV4HttpSigner();
-
-        private final String name;
-        private final String value;
-
-        private AddHeaderSigner(final String name, final String value) {
-            this.name = name;
-            this.value = value;
-        }
-
-        @Override
-        public SignedRequest sign(SignRequest signRequest) {
-            SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
-                    .uri(signRequest.request().getUri())
-                    .method(signRequest.request().method())
-                    .headers(signRequest.request().headers())
-                    .appendHeader(name, value)
-                    .appendHeader("resourcePath", signRequest.request().getUri().getRawPath());
-
-            if (signRequest.payload().isPresent()) {
-                ContentStreamProvider contentStreamProvider = (ContentStreamProvider) signRequest.payload().get();
-                InputStream payloadStream = contentStreamProvider.newStream();
-                ContentStreamProvider newContentStreamProvider = ContentStreamProvider.fromInputStream(payloadStream);
-
-                request
-                        .contentStreamProvider(newContentStreamProvider)
-                        .appendHeader("signedContentLength",
-                                Long.toString(getContentLength(newContentStreamProvider.newStream())))
-                        .build();
-            }
-
-            SdkHttpFullRequest requestBuilt = request.build();
-
-            SignedRequest signedRequest =
-                signer.sign(r -> r
-                        .identity(
-                                AnonymousCredentialsProvider.create().resolveCredentials())
-                        .request(requestBuilt)
-                        .payload(requestBuilt.contentStreamProvider().orElse(null))
-                        .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "servicename")
-                        .putProperty(AwsV4HttpSigner.REGION_NAME, "us-west-2")
-                        .putProperty(AwsV4HttpSigner.DOUBLE_URL_ENCODE, false)
-                        .putProperty(AwsV4HttpSigner.NORMALIZE_PATH, false));
-
-            return signedRequest;
-        }
-
-        private static int getContentLength(final InputStream content) {
-            try {
-                return IoUtils.toByteArray(content).length;
-            } catch (IOException e) {
-                return -1;
-            }
-        }
-
-        @Override
-        public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest asyncSignRequest) {
-            return null;
-        }
     }
 }


### PR DESCRIPTION
*Purpose of changes:*

Prepare for adding failing tests that cover the issue reported in https://github.com/acm19/aws-request-signing-apache-interceptor/issues/101 (this is impacting us as well). And then subsequently I'd like to follow-up with a patch to fix that issue as well, potentially using the approach mentioned [here](https://github.com/acm19/aws-request-signing-apache-interceptor/issues/101#issuecomment-1556150389).

*Description of changes:*

* Add com.squareup.okhttp3:mockwebserver as a test dependency to run a "real" HTTP server for the tests
* Update tests in AwsRequestSigningApacheV5InterceptorTest to verify request headers/content as seen by the server
* Update tests in AwsRequestSigningApacheInterceptorTest to verify request headers/content as seen by the server
* Drop MockRequestLine from AwsRequestSigningApacheInterceptorTest since it's no longer needed
* Extract the duplicated AddHeaderSigner class from AwsRequestSigningApacheInterceptorTest/AwsRequestSigningApacheV5InterceptorTest so a separate source file

Note: This adds some additional output when running tests. I think this is due to some of the log4j config/deps. I'm happy to add config to suppress it for test execution.

![Screenshot 2024-11-13 at 4 33 14 PM](https://github.com/user-attachments/assets/c2c58a69-8f3a-479a-820b-13e7bd8d7c3c)

### Pull Request Checklist:

- [ ] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
