### PR TITLE
Remove usage of deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### 3.0.1 (Next)
-* [#129](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/129): Dispatch/verify requests against mockwebserver - [@bobziuchkovski](https://github.com/bobziuchkovski)
+* [#130](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/130):  Remove usage of deprecated methods - [@acm19](https://github.com/acm19).
+* [#129](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/129): Dispatch/verify requests against mockwebserver - [@bobziuchkovski](https://github.com/bobziuchkovski).
 
 ### 3.0.0 (2024/09/29)
-* [#125](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/125): Use to use `AwsV4HttpSigner` - [@GeorgeVincentDepop](https://github.com/GeorgeVincentDepop)
+* [#125](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/125): Use to use `AwsV4HttpSigner` - [@GeorgeVincentDepop](https://github.com/GeorgeVincentDepop).
 
 ### 2.3.1 (2023/06/11)
 * [#107](https://github.com/acm19/aws-request-signing-apache-interceptor/pull/107): Automate the release fully by auto closing it - [@acm19](https://github.com/acm19).

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5InterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5InterceptorTest.java
@@ -21,7 +21,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.impl.BasicEntityDetails;
 import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -37,7 +36,6 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
 class AwsRequestSigningApacheV5InterceptorTest {
-    private static final BasicEntityDetails ENTITY_DETAILS = new BasicEntityDetails(0, ContentType.TEXT_XML);
     private MockWebServer server;
     private CloseableHttpClient client;
 
@@ -69,7 +67,7 @@ class AwsRequestSigningApacheV5InterceptorTest {
         HttpGet request = new HttpGet(server.url("/query?a=b").toString());
         request.addHeader("foo", "bar");
 
-        client.execute(request);
+        client.execute(request, response -> "ignored");
         RecordedRequest recorded = server.takeRequest();
 
         assertEquals("bar", recorded.getHeader("foo"));
@@ -89,7 +87,7 @@ class AwsRequestSigningApacheV5InterceptorTest {
                 payloadData.length, ContentType.TEXT_XML);
         request.setEntity(httpEntity);
 
-        client.execute(request);
+        client.execute(request, response -> "ignored");
         RecordedRequest recorded = server.takeRequest();
 
         assertEquals("bar", recorded.getHeader("foo"));
@@ -108,7 +106,7 @@ class AwsRequestSigningApacheV5InterceptorTest {
         request.setEntity(new StringEntity(data));
         request.addHeader("foo", "bar");
 
-        client.execute(request);
+        client.execute(request, response -> "ignored");
         RecordedRequest recorded = server.takeRequest();
 
         assertEquals("bar", recorded.getHeader("foo"));
@@ -131,7 +129,7 @@ class AwsRequestSigningApacheV5InterceptorTest {
         request.setHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
         request.setEntity(entity);
 
-        client.execute(request);
+        client.execute(request, response -> "ignored");
         RecordedRequest recorded = server.takeRequest();
 
         assertEquals("wuzzle", recorded.getHeader("Signature"));


### PR DESCRIPTION
Replaces usage of deprecated methods in newly created tests to prevent them from breaking if the deprecated method is removed. Removes unused variable.

### Pull Request Checklist:

- [x] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
