### PR TITLE
[WIP] Cover sync and async v5 clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.9.0</version>

--- a/src/main/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5ExecInterceptor.java
+++ b/src/main/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5ExecInterceptor.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The AWS Request Signing Interceptor Contributors require
+ * contributions made to this file be licensed under the
+ * Apache-2.0 license or a compatible open source license.
+ */
+
+package io.github.acm19.aws.interceptor.http;
+
+import java.io.IOException;
+import org.apache.hc.client5.http.async.AsyncExecCallback;
+import org.apache.hc.client5.http.async.AsyncExecChain;
+import org.apache.hc.client5.http.async.AsyncExecChain.Scope;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * An {@link ExecChainHandler} that signs requests for any AWS service
+ * running in a specific region using an AWS {@link HttpSigner} and
+ * {@link AwsCredentialsProvider}.
+ */
+public final class AwsRequestSigningApacheV5ExecInterceptor implements AsyncExecChainHandler {
+    private final RequestSigner signer;
+
+    /**
+     * Creates an {@code AwsRequestSigningApacheV5ExecInterceptor} with the
+     * ability to sign request for a specific service in a region and
+     * defined credentials.
+     *
+     * @param service                service the client is connecting to
+     * @param signer                 signer implementation.
+     * @param awsCredentialsProvider source of AWS credentials for signing
+     * @param region                 signing region
+     */
+    public AwsRequestSigningApacheV5ExecInterceptor(String service,
+                                                HttpSigner<AwsCredentialsIdentity> signer,
+                                                AwsCredentialsProvider awsCredentialsProvider,
+                                                Region region) {
+        this.signer = new RequestSigner(service, signer, awsCredentialsProvider, region);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(HttpRequest request,
+                        AsyncEntityProducer entityProducer,
+                        Scope scope, AsyncExecChain chain,
+                        AsyncExecCallback callback) throws HttpException, IOException {
+        chain.proceed(request, entityProducer, scope, callback);
+    }
+}

--- a/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5AsyncExecInterceptorAdapter.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5AsyncExecInterceptorAdapter.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The AWS Request Signing Interceptor Contributors require
+ * contributions made to this file be licensed under the
+ * Apache-2.0 license or a compatible open source license.
+ */
+
+package io.github.acm19.aws.interceptor.http;
+
+import java.io.IOException;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+
+class ApacheV5AsyncExecInterceptorAdapter implements ApacheV5ClientAdapter {
+    private final CloseableHttpAsyncClient client;
+
+    ApacheV5AsyncExecInterceptorAdapter(AwsRequestSigningApacheV5ExecInterceptor interceptor) {
+        this.client = HttpAsyncClients.custom().addExecInterceptorLast("custom", interceptor).build();
+        this.client.start();
+    }
+
+    @Override
+    public void execute(ClassicHttpRequest request) throws Exception {
+        SimpleRequestBuilder requestBuilder = SimpleRequestBuilder.copy(request);
+        HttpEntity entity = request.getEntity();
+        if (entity != null) {
+            requestBuilder.setBody(entity.getContent().readAllBytes(), ContentType.parse(entity.getContentType()));
+        }
+        client.execute(requestBuilder.build(), null).get();
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+}

--- a/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5AsyncRequestInterceptorAdapter.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5AsyncRequestInterceptorAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The AWS Request Signing Interceptor Contributors require
+ * contributions made to this file be licensed under the
+ * Apache-2.0 license or a compatible open source license.
+ */
+
+package io.github.acm19.aws.interceptor.http;
+
+import java.io.IOException;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+
+class ApacheV5AsyncRequestInterceptorAdapter implements ApacheV5ClientAdapter {
+    private final CloseableHttpAsyncClient client;
+
+    ApacheV5AsyncRequestInterceptorAdapter(AwsRequestSigningApacheV5Interceptor interceptor) {
+        this.client = HttpAsyncClients.custom().addRequestInterceptorLast(interceptor).build();
+        this.client.start();
+    }
+
+    @Override
+    public void execute(ClassicHttpRequest request) throws Exception {
+        SimpleHttpRequest sr = SimpleRequestBuilder.copy(request).build();
+        client.execute(sr, null).get();
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+}

--- a/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5ClientAdapter.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5ClientAdapter.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The AWS Request Signing Interceptor Contributors require
+ * contributions made to this file be licensed under the
+ * Apache-2.0 license or a compatible open source license.
+ */
+
+package io.github.acm19.aws.interceptor.http;
+
+import java.io.Closeable;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+
+interface ApacheV5ClientAdapter extends Closeable {
+    void execute(ClassicHttpRequest request) throws Exception;
+}

--- a/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5SyncRequestInterceptorAdapter.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/ApacheV5SyncRequestInterceptorAdapter.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The AWS Request Signing Interceptor Contributors require
+ * contributions made to this file be licensed under the
+ * Apache-2.0 license or a compatible open source license.
+ */
+
+package io.github.acm19.aws.interceptor.http;
+
+import java.io.IOException;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+
+class ApacheV5SyncRequestInterceptorAdapter implements ApacheV5ClientAdapter {
+    private final CloseableHttpClient client;
+
+    ApacheV5SyncRequestInterceptorAdapter(AwsRequestSigningApacheV5Interceptor interceptor) {
+        this.client = HttpClients.custom().addRequestInterceptorLast(interceptor).build();
+    }
+
+    @Override
+    public void execute(ClassicHttpRequest request) throws Exception {
+        client.execute(request);
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+}

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5InterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheV5InterceptorTest.java
@@ -22,6 +22,7 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.impl.BasicEntityDetails;
 import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -49,14 +50,21 @@ class AwsRequestSigningApacheV5InterceptorTest {
     static Stream<Arguments> allClients() {
         AwsCredentialsProvider anonymousCredentialsProvider = StaticCredentialsProvider
                 .create(AnonymousCredentialsProvider.create().resolveCredentials());
-        AwsRequestSigningApacheV5Interceptor interceptor = new AwsRequestSigningApacheV5Interceptor("servicename",
+        AwsRequestSigningApacheV5Interceptor interceptor = new AwsRequestSigningApacheV5Interceptor(
+                "servicename",
+                new AddHeaderSigner("Signature", "wuzzle"),
+                anonymousCredentialsProvider,
+                Region.AF_SOUTH_1);
+        AwsRequestSigningApacheV5ExecInterceptor execInterceptor = new AwsRequestSigningApacheV5ExecInterceptor(
+                "servicename",
                 new AddHeaderSigner("Signature", "wuzzle"),
                 anonymousCredentialsProvider,
                 Region.AF_SOUTH_1);
 
         return Stream.of(
                 Arguments.of(Named.of("SyncRequestInterceptor", new ApacheV5SyncRequestInterceptorAdapter(interceptor))),
-                Arguments.of(Named.of("AsyncRequestInterceptor", new ApacheV5AsyncRequestInterceptorAdapter(interceptor)))
+                Arguments.of(Named.of("AsyncRequestInterceptor", new ApacheV5AsyncRequestInterceptorAdapter(interceptor))),
+                Arguments.of(Named.of("AsyncExecInterceptor", new ApacheV5AsyncExecInterceptorAdapter(execInterceptor)))
         );
     }
 


### PR DESCRIPTION
Issue https://github.com/acm19/aws-request-signing-apache-interceptor/issues/101

*Description of changes:*
- Add junit-jupiter-params test dependency
- Refactor v5 interceptor tests to execute against both sync and async v5 clients
  * This reproduces the error on the async v5 clients from Issue #101 
- Add initial stubbed implementation for an async exec interceptor

**Notes**

- **This is still WIP. Opening for visibility and potential discussion.**
- I have some WIP code to implement that subbed `AwsRequestSigningApacheV5ExecInterceptor` class locally but it is _very_ ugly. I don't think I realized just how nasty it would be trying to marry the async apache exec interceptor methods to the async AWS SDK signer methods along with handling the async request/body construction.
- I noticed junit-jupiter-params test output is tough to read with maven/surefire. It's a bit hard to tell which parameterized tests are which. You _can_ read it, but you have to know the "[3]" in `<TEST_CLASS>.testGzipCompressedContent(ApacheV5ClientAdapter)[3]` means it's the third parameterized argument. 😞 With gradle you get `<TEST_CLASS> testGzipCompressedContent(ApacheV5ClientAdapter) > [3] AsyncExecInterceptor` showing the named parameter. However, I'm not sure how to configure maven/surefire to do the same.

### Pull Request Checklist:

- [ ] I have added a contribution line at the top of [CHANGELOG.md](CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
